### PR TITLE
Schedule `_drawFrame()` timer before running `_beginFrame()`

### DIFF
--- a/engine/lib/src/platform_dispatcher.dart
+++ b/engine/lib/src/platform_dispatcher.dart
@@ -574,9 +574,7 @@ class PlatformDispatcher {
         final int microseconds = _frameTime.inMicroseconds;
         _frameTime += const Duration(milliseconds: 16);
         Timer.run(() {
-          final Stopwatch beginSw = Stopwatch()..start();
-          _beginFrame(microseconds);
-          beginSw.stop();
+          late final Stopwatch beginSw;
           Timer.run(() {
             final Stopwatch drawSw = Stopwatch()..start();
             _drawFrame();
@@ -587,6 +585,9 @@ class PlatformDispatcher {
                 drawSw.elapsedMicroseconds / 1000);
             _frameCount += 1;
           });
+          beginSw = Stopwatch()..start();
+          _beginFrame(microseconds);
+          beginSw.stop();
         });
       },
     );


### PR DESCRIPTION
A `_beginFrame()` seems to schedule the next frame interanally. If the `_beginFrame()` takes a long time, it will finish after the expiration date of the next frame timer.

That in return makes a `Timer.run(() => _drawFrame())` be scheduled *after* the next frame callback is already run. Though we want to ensure the `_beginFrame()` and `_drawFrame()` are together before starting to work on the next frame. We only want microtasks to be drained in-between those two.

(This is how C++ engine works)

We can get similar semantics by scheduling the `_drawFrame()` timer even before running the `_beginFrame()` code.

Issue https://github.com/dart-lang/flute/issues/23
Issue https://github.com/dart-lang/sdk/issues/59666